### PR TITLE
add npm test and build and update readme with develop

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,3 +88,8 @@ Napoleon.modifyState({
 There is a third configuration that can be set: `replace`. Setting `replace` to true will replace the existing browser
 history item instead of creating a new one.
 - give example -
+
+###Develop
+- `npm install` install packages
+- `npm test` will build napoleon, build tests, and run tests
+- `npm run build` will build napoleon

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -4,25 +4,30 @@ var uglify = require('gulp-uglify');
 var mocha = require('gulp-mocha');
 
 gulp.task('default', function(){
-    gulp.src('src/napoleon.js')
+    var stream = gulp.src('src/napoleon.js')
         .pipe(babel({
             loose: ['es6.classes', 'es6.destructuring', 'es6.spread'],
             modules: 'umd'
         }))
         .pipe(uglify())
         .pipe(gulp.dest('build'));
+    return stream;
 });
 
 gulp.task('build-tests', ['default'], function(){
-    gulp.src('tests/*.js')
+    var stream = gulp.src('tests/*.js')
         .pipe(babel({
             loose: ['es6.classes', 'es6.destructuring', 'es6.spread'],
             modules: 'umd'
         }))
         .pipe(gulp.dest('build/tests'));
+    return stream;
 });
 
-gulp.task('test', ['build-tests'], function(){
-    gulp.src('build/tests/*.js', {read: false})
+gulp.task('run-tests', ['build-tests'], function(){
+    var stream = gulp.src('build/tests/*.js', {read: false})
     .pipe(mocha({reporter: 'nyan'}));
+    return stream;
 });
+
+gulp.task('test', ['run-tests']);

--- a/package.json
+++ b/package.json
@@ -9,6 +9,10 @@
     "url": "https://github.com/Craftsy/napoleon.git"
   },
   "main": "build/napoleon.js",
+  "scripts": {
+    "test": "gulp test",
+    "build": "gulp"
+  },
   "contributors": [
     {
       "name": "Chandler Prall",


### PR DESCRIPTION
- add `npm test`
- add `npm run build`
- update readme

Had to create streams and return them in the gulp tasks so that `default` and `build-tests` finish before tests are ran.
